### PR TITLE
retreived categories

### DIFF
--- a/TheHoyaNews/server/WPrequeststest.js
+++ b/TheHoyaNews/server/WPrequeststest.js
@@ -1,0 +1,54 @@
+import axios from 'axios';
+import { writeFileSync } from 'fs'; // To write the CSV file
+import { Parser } from 'json2csv';  // To convert JSON to CSV
+
+export default async function requesthoyawp() {
+  let categorieslist = [];
+  let page = 1;
+  let totalPages = 1;
+  
+  try {
+    while (page <= totalPages) {
+      const response = await axios.get('https://thehoya.com/wp-json/wp/v2/categories', {
+        params: { per_page: 100, page },
+      });
+
+      if (Array.isArray(response.data)) {
+        categorieslist = [...categorieslist, ...response.data];
+      }
+
+      if (response.headers && response.headers['x-wp-totalpages']) {
+        totalPages = parseInt(response.headers['x-wp-totalpages'], 10);
+      }
+
+      page += 1;
+    }
+  } catch (error) {
+    console.log('Error fetching articles:', error.message);
+    return [];
+  }
+
+  const categories = categorieslist.map((category) => ({
+    name: category.name,
+    id: category.id,
+    count: category.count,
+    link: category.link,  // Link to the category page
+    posts_link: category._links['wp:post_type'] 
+                 ? category._links['wp:post_type'][0].href 
+                 : '',  // Link to posts in this category if available
+  }));
+
+  // Convert to CSV
+  const fields = ['name', 'id', 'count', 'link', 'posts_link']; // Fields to include in the CSV
+  const json2csvParser = new Parser({ fields });
+  const csv = json2csvParser.parse(categories);
+
+  // Write CSV to file
+  writeFileSync('categories.csv', csv);
+
+  console.log('CSV file created: categories.csv');
+  
+  return categories;
+}
+
+requesthoyawp();

--- a/TheHoyaNews/server/index.js
+++ b/TheHoyaNews/server/index.js
@@ -10,7 +10,7 @@ app.use(cors());
 // Endpoint to get articles from the WordPress API
 app.get('/getarticles', async (req, res) => {
   try {
-    const response = await axios.get('https://your-wordpress-site.com/wp-json/wp/v2/posts', {
+    const response = await axios.get('https://thehoya.com/wp-json/wp/v2/posts', {
       params: { per_page: 20 },
     });
     res.json(response.data);

--- a/TheHoyaNews/server/package-lock.json
+++ b/TheHoyaNews/server/package-lock.json
@@ -11,8 +11,15 @@
       "dependencies": {
         "axios": "^1.7.7",
         "cors": "^2.8.5",
-        "express": "^4.21.0"
+        "express": "^4.21.0",
+        "json2csv": "^6.0.0-alpha.2"
       }
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.6.tgz",
+      "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -104,6 +111,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/content-disposition": {
@@ -470,6 +486,30 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/json2csv": {
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@streamparser/json": "^0.0.6",
+        "commander": "^6.2.0",
+        "lodash.get": "^4.4.2"
+      },
+      "bin": {
+        "json2csv": "bin/json2csv.js"
+      },
+      "engines": {
+        "node": ">= 12",
+        "npm": ">= 6.13.0"
+      }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",

--- a/TheHoyaNews/server/package.json
+++ b/TheHoyaNews/server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js"
@@ -13,6 +14,7 @@
   "dependencies": {
     "axios": "^1.7.7",
     "cors": "^2.8.5",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "json2csv": "^6.0.0-alpha.2"
   }
 }


### PR DESCRIPTION
WPrequest.js, queries the WordPress API to retrieve all categories from The Hoya and exports the data to a CSV file. The CSV contains category names, IDs, and associated href links, making it easy to fetch articles by category. we can use the links to request articles for specific Categories such as Featured News, Opinion, and Guide a. The next step in enhancing the script is to build functions that take a category ID as a parameter and return an array of objects containing article content, headers, and related metadata for each retrieved article. This will streamline the process of gathering and organizing articles based on categories.

 MUST INSTALL :npm install json2csv in server folder b4 running
